### PR TITLE
Enforce doc blocks with single line on methods too

### DIFF
--- a/src/Lcobucci/ruleset.xml
+++ b/src/Lcobucci/ruleset.xml
@@ -34,4 +34,6 @@
             </property>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
 </ruleset>

--- a/tests/ExampleClassWithNoViolation.php
+++ b/tests/ExampleClassWithNoViolation.php
@@ -97,4 +97,9 @@ final class ExampleClassWithNoViolation
         echo $this->test;
         echo count($this->testing);
     }
+
+    /** @test */
+    public function sampleWithOnlyOneAnnotation(): void
+    {
+    }
 }


### PR DESCRIPTION
When there's only one annotation or a simple description we don't need to have multiple lines.