### PR TITLE
Disallow implicit array creation

### DIFF
--- a/src/Lcobucci/ruleset.xml
+++ b/src/Lcobucci/ruleset.xml
@@ -36,4 +36,5 @@
     </rule>
 
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
+    <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
 </ruleset>


### PR DESCRIPTION
Because they are just unnecessary.