### PR TITLE
Enforce a basic class structure

### DIFF
--- a/src/Lcobucci/ruleset.xml
+++ b/src/Lcobucci/ruleset.xml
@@ -37,4 +37,16 @@
 
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+
+    <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
+        <properties>
+            <property name="groups" type="array">
+                <element value="uses"/>
+                <element value="public constants, constants"/>
+                <element value="public properties, protected properties, private properties, static properties"/>
+                <element value="constructor"/>
+                <element value="methods"/>
+            </property>
+        </properties>
+    </rule>
 </ruleset>

--- a/tests/ExampleOfClassStructure.php
+++ b/tests/ExampleOfClassStructure.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci;
+
+/**
+ * Order should be:
+ *
+ * 1. traits
+ * 2. Constants (no strict order regarding visibility)
+ * 3. Properties (no strict order regarding visibility/static)
+ * 4. Constructor
+ * 5. All remaining methods (no strict order regarding visibility/static/final/magic)
+ */
+class ExampleOfClassStructure
+{
+    use RandomTrait;
+
+    private const FOO   = 1;
+    public const BAR    = 2;
+    private const BAZ   = 3;
+    protected const QUX = 4;
+
+    public int $foo;
+    protected string $bar;
+    public static int $baz = self::BAZ;
+    private int $qux;
+
+    public function __construct()
+    {
+        $this->foo = self::FOO;
+        $this->qux = self::QUX;
+    }
+
+    public function a(): void
+    {
+        self::b();
+
+        echo $this->qux;
+    }
+
+    public function __get(string $name): bool
+    {
+        return false;
+    }
+
+    private static function b(): void
+    {
+    }
+
+    public function __isset(string $name): bool
+    {
+        return false;
+    }
+
+    final protected function c(): void
+    {
+    }
+
+    /** @param mixed $value */
+    public function __set(string $name, $value): void
+    {
+    }
+}


### PR DESCRIPTION
Providing a simple separation between element groups but still leaving lots of room for flexibility.