### PR TITLE
Fix template grouping position

### DIFF
--- a/src/Lcobucci/ruleset.xml
+++ b/src/Lcobucci/ruleset.xml
@@ -30,6 +30,7 @@
                 <element value="@uses"/>
                 <element value="@Given, @Then, @When, @Transform, @BeforeSuite, @AfterSuite, @BeforeFeature, @AfterFeature, @BeforeScenario, @AfterScenario, @BeforeStep, @AfterStep"/>
                 <element value="@ORM\,@ODM\"/>
+                <element value="@template"/>
                 <element value="@param"/>
                 <element value="@return"/>
                 <element value="@throws"/>

--- a/tests/ExampleClassWithNoViolation.php
+++ b/tests/ExampleClassWithNoViolation.php
@@ -99,4 +99,16 @@ final class ExampleClassWithNoViolation
     public function sampleWithOnlyOneAnnotation(): void
     {
     }
+
+    /**
+     * @template T
+     *
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    public function sampleForGenerics(string $className): object
+    {
+        return new $className();
+    }
 }


### PR DESCRIPTION
We forgot to configure the `@template` annotation properly, making `phpcbf` to position it at the bottom of the doc block.